### PR TITLE
fix(ci): 태그 버전과 package.json 버전 일치 시 npm version 에러 방지

### DIFF
--- a/.github/workflows/build-and-release.yml
+++ b/.github/workflows/build-and-release.yml
@@ -31,9 +31,14 @@ jobs:
         if: startsWith(github.ref, 'refs/tags/')
         shell: bash
         run: |
-          VERSION=${GITHUB_REF#refs/tags/}
-          npm version $VERSION --no-git-tag-version
-          echo "Updated package.json version to $VERSION"
+          TAG_VERSION=${GITHUB_REF#refs/tags/v}
+          CURRENT_VERSION=$(node -p "require('./package.json').version")
+          if [ "$TAG_VERSION" != "$CURRENT_VERSION" ]; then
+            npm version "$TAG_VERSION" --no-git-tag-version
+            echo "Updated package.json version to $TAG_VERSION"
+          else
+            echo "package.json version ($CURRENT_VERSION) already matches tag, skipping update"
+          fi
 
       - name: Build
         run: npm run build


### PR DESCRIPTION
package.json에 이미 동일 버전이 설정된 경우 `npm version`이
"Version not changed" 에러를 발생시키는 문제 수정.
태그에서 v 접두사를 제거하고, 현재 버전과 비교하여 다를 때만 업데이트한다.