### PR TITLE
docs: Build from Source 지침 수정

### DIFF
--- a/packages/docs/src/index.html
+++ b/packages/docs/src/index.html
@@ -363,11 +363,21 @@
           class="mt-8 rounded-2xl border border-gray-200 bg-gray-50 p-6 dark:border-gray-800 dark:bg-gray-900"
         >
           <h3 class="mb-3 text-lg font-semibold">Build from Source</h3>
+          <p class="mb-3 text-sm text-gray-600 dark:text-gray-400">
+            Requires <strong>Node.js 18+</strong> and <strong>npm 10+</strong>
+          </p>
           <pre
             class="overflow-x-auto rounded-lg bg-gray-900 p-4 text-sm text-gray-100 dark:bg-gray-950"
-          ><code>npm install
+          ><code>git clone https://github.com/Einere/tomato-mien.git
+cd tomato-mien
+npm install
+
+# Development (with hot reload)
+npm run electron:dev
+
+# Production build (run locally)
 npm run build
-npm run electron:build</code></pre>
+npm run electron</code></pre>
         </div>
       </div>
     </section>


### PR DESCRIPTION
## Summary

- 기존 `electron:build`(코드 서명/공증 필요) 대신 일반 개발자가 로컬에서 빌드할 수 있는 올바른 지침으로 수정
- `git clone`, Node.js/npm 요구사항, 개발 모드와 프로덕션 빌드 명령어를 구분하여 안내

## Changes

- `git clone` 및 `cd` 단계 추가
- Node.js 18+, npm 10+ 요구사항 명시
- 개발 모드: `npm run electron:dev` (hot reload)
- 프로덕션 로컬 빌드: `npm run build` + `npm run electron`
- 메인테이너 전용 `electron:build` (인스톨러 패키징 + 코드 서명/공증) 제거

## Test plan

- [x] 랜딩 페이지에서 Build from Source 섹션이 올바르게 렌더링되는지 확인
- [x] 지침대로 `npm install` → `npm run electron:dev` 실행 가능 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)