### PR TITLE
docs: 개인정보 처리방침 페이지 추가

### DIFF
--- a/packages/docs/package.json
+++ b/packages/docs/package.json
@@ -3,7 +3,7 @@
   "private": true,
   "scripts": {
     "dev": "npm run build && concurrently \"npx @tailwindcss/cli -i src/styles.css -o dist/styles.css --watch\" \"serve dist -l 3000\"",
-    "build": "npx @tailwindcss/cli -i src/styles.css -o dist/styles.css --minify && cp src/index.html dist/index.html && rm -rf dist/assets && cp -r assets dist/assets"
+    "build": "npx @tailwindcss/cli -i src/styles.css -o dist/styles.css --minify && cp src/index.html dist/index.html && cp src/privacy.html dist/privacy.html && rm -rf dist/assets && cp -r assets dist/assets"
   },
   "dependencies": {
     "@tomato-mien/design-tokens": "*"

--- a/packages/docs/src/index.html
+++ b/packages/docs/src/index.html
@@ -401,6 +401,13 @@ npm run electron</code></pre>
           >
             Issues & PRs Welcome
           </a>
+          <span class="text-gray-300 dark:text-gray-700">|</span>
+          <a
+            href="privacy.html"
+            class="transition hover:text-gray-900 dark:hover:text-gray-300"
+          >
+            Privacy Policy
+          </a>
         </div>
         <p>MIT License &copy; Einere</p>
       </div>

--- a/packages/docs/src/privacy.html
+++ b/packages/docs/src/privacy.html
@@ -1,0 +1,117 @@
+<!doctype html>
+<html lang="ko" class="scroll-smooth">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Privacy Policy - Tomato Mien</title>
+    <link rel="icon" href="assets/icon.ico" sizes="48x48" />
+    <link rel="stylesheet" href="styles.css" />
+  </head>
+  <body
+    class="bg-white text-gray-900 antialiased dark:bg-gray-950 dark:text-gray-100"
+  >
+    <div class="mx-auto max-w-3xl px-4 py-16 sm:py-24">
+      <a
+        href="./"
+        class="text-tomato-600 dark:text-tomato-400 mb-8 inline-flex items-center gap-1 text-sm font-medium transition hover:underline"
+      >
+        &larr; Back to Home
+      </a>
+
+      <h1 class="mb-8 text-3xl font-bold tracking-tight sm:text-4xl">
+        Privacy Policy
+      </h1>
+
+      <p class="mb-6 text-sm text-gray-500 dark:text-gray-500">
+        Last updated: February 16, 2026
+      </p>
+
+      <div class="space-y-8 text-gray-700 leading-relaxed dark:text-gray-300">
+        <section>
+          <h2 class="mb-3 text-xl font-semibold text-gray-900 dark:text-gray-100">
+            Overview
+          </h2>
+          <p>
+            Tomato Mien is a rule-based alarm desktop application. We are committed to
+            protecting your privacy. This policy explains how we handle your data.
+          </p>
+        </section>
+
+        <section>
+          <h2 class="mb-3 text-xl font-semibold text-gray-900 dark:text-gray-100">
+            Data Collection
+          </h2>
+          <p>
+            <strong>We do not collect any personal data.</strong> Tomato Mien does not
+            require an account, login, or any form of registration.
+          </p>
+        </section>
+
+        <section>
+          <h2 class="mb-3 text-xl font-semibold text-gray-900 dark:text-gray-100">
+            Data Storage
+          </h2>
+          <p>
+            All data (alarm rules, app settings) is stored locally on your device
+            using IndexedDB. No data is transmitted to external servers.
+          </p>
+        </section>
+
+        <section>
+          <h2 class="mb-3 text-xl font-semibold text-gray-900 dark:text-gray-100">
+            Network Usage
+          </h2>
+          <p>
+            Tomato Mien does not make any network requests. The app works entirely
+            offline. The only exception is the automatic update check for the
+            non-App Store version, which contacts GitHub Releases.
+          </p>
+        </section>
+
+        <section>
+          <h2 class="mb-3 text-xl font-semibold text-gray-900 dark:text-gray-100">
+            Analytics & Tracking
+          </h2>
+          <p>
+            We do not use any analytics, tracking, or telemetry tools.
+            No usage data is collected or shared with third parties.
+          </p>
+        </section>
+
+        <section>
+          <h2 class="mb-3 text-xl font-semibold text-gray-900 dark:text-gray-100">
+            Third-Party Services
+          </h2>
+          <p>
+            Tomato Mien does not integrate with any third-party services
+            or SDKs that collect user data.
+          </p>
+        </section>
+
+        <section>
+          <h2 class="mb-3 text-xl font-semibold text-gray-900 dark:text-gray-100">
+            Changes to This Policy
+          </h2>
+          <p>
+            If we make changes to this privacy policy, we will update this page
+            with the new effective date.
+          </p>
+        </section>
+
+        <section>
+          <h2 class="mb-3 text-xl font-semibold text-gray-900 dark:text-gray-100">
+            Contact
+          </h2>
+          <p>
+            If you have any questions about this privacy policy, please open an issue on our
+            <a
+              href="https://github.com/Einere/tomato-mien/issues"
+              class="text-tomato-600 dark:text-tomato-400 underline"
+              >GitHub repository</a
+            >.
+          </p>
+        </section>
+      </div>
+    </div>
+  </body>
+</html>


### PR DESCRIPTION
## Summary
- 개인정보 처리방침 페이지(`privacy.html`) 추가 — 데이터 미수집, 로컬 저장, 네트워크 미사용 명시
- 홈페이지 footer에 Privacy Policy 링크 추가
- Mac App Store 제출 시 Privacy Policy URL로 사용: `https://einere.github.io/tomato-mien/privacy.html`

## Test plan
- [x] `npm run docs:build` 정상 빌드 확인
- [x] `privacy.html` 페이지 정상 렌더링 확인
- [x] footer의 Privacy Policy 링크 동작 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)