### PR TITLE
style: BottomNav 화면 하단 고정 및 접근성 개선

### DIFF
--- a/src/components/Layout/AppShell.tsx
+++ b/src/components/Layout/AppShell.tsx
@@ -22,7 +22,7 @@ export function AppShell() {
 
   return (
     <div className="bg-background">
-      <div className="mx-auto flex min-h-screen max-w-xl flex-col">
+      <div className="mx-auto flex h-screen max-w-xl flex-col">
         <main className="flex-1 overflow-y-auto">
           <CurrentView view={view} />
         </main>

--- a/src/components/Layout/BottomNav.tsx
+++ b/src/components/Layout/BottomNav.tsx
@@ -31,6 +31,7 @@ export function BottomNav() {
         return (
           <button
             key={tab.id}
+            aria-current={isActive ? "page" : undefined}
             onClick={() => {
               if (tab.id === "dashboard") {
                 setView("dashboard");

--- a/src/components/__tests__/AppShell.test.tsx
+++ b/src/components/__tests__/AppShell.test.tsx
@@ -1,0 +1,59 @@
+import { describe, it, expect, vi } from "vitest";
+import { render, screen } from "@testing-library/react";
+import { Provider, createStore } from "jotai";
+import { AppShell } from "@/components/Layout/AppShell";
+import { viewAtom } from "@/store";
+
+vi.mock("@/hooks/useAlarmService", () => ({
+  useAlarmService: vi.fn(),
+}));
+
+vi.mock("@/hooks/useElectronMenu", () => ({
+  useElectronMenu: vi.fn(),
+}));
+
+function renderAppShell(store: ReturnType<typeof createStore>) {
+  return render(
+    <Provider store={store}>
+      <AppShell />
+    </Provider>,
+  );
+}
+
+describe("AppShell 레이아웃", () => {
+  it("main 영역과 BottomNav를 렌더링한다", () => {
+    const store = createStore();
+    renderAppShell(store);
+
+    expect(screen.getByRole("main")).toBeInTheDocument();
+    expect(screen.getByRole("navigation")).toBeInTheDocument();
+  });
+
+  // Regression: min-h-screen → h-screen 변경으로 BottomNav 하단 고정
+  it("컨테이너가 h-screen으로 뷰포트 높이에 고정된다", () => {
+    const store = createStore();
+    renderAppShell(store);
+
+    const nav = screen.getByRole("navigation");
+    const container = nav.closest(".h-screen");
+    expect(container).not.toBeNull();
+  });
+
+  it("BottomNav가 main 영역 뒤에 위치한다", () => {
+    const store = createStore();
+    renderAppShell(store);
+
+    const main = screen.getByRole("main");
+    const nav = screen.getByRole("navigation");
+    expect(main.nextElementSibling).toBe(nav);
+  });
+
+  it("dashboard 뷰에서 DashboardView를 렌더링한다", () => {
+    const store = createStore();
+    store.set(viewAtom, "dashboard");
+    renderAppShell(store);
+
+    expect(screen.getByRole("heading", { name: "Rules" })).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: /create/i })).toBeInTheDocument();
+  });
+});

--- a/src/components/__tests__/BottomNav.test.tsx
+++ b/src/components/__tests__/BottomNav.test.tsx
@@ -1,0 +1,83 @@
+import { describe, it, expect } from "vitest";
+import { render, screen, fireEvent } from "@testing-library/react";
+import { Provider, createStore } from "jotai";
+import { BottomNav } from "@/components/Layout/BottomNav";
+import { viewAtom } from "@/store";
+
+function renderBottomNav(store: ReturnType<typeof createStore>) {
+  return render(
+    <Provider store={store}>
+      <BottomNav />
+    </Provider>,
+  );
+}
+
+function getTabButton(label: string): HTMLElement {
+  const button = screen
+    .getByText(label)
+    .closest("button") as HTMLElement | null;
+  expect(button).not.toBeNull();
+  return button!;
+}
+
+describe("BottomNav", () => {
+  it("Rules와 Settings 탭을 렌더링한다", () => {
+    const store = createStore();
+    renderBottomNav(store);
+
+    expect(screen.getByText("Rules")).toBeInTheDocument();
+    expect(screen.getByText("Settings")).toBeInTheDocument();
+  });
+
+  it("dashboard 뷰일 때 Rules 탭이 활성화된다", () => {
+    const store = createStore();
+    store.set(viewAtom, "dashboard");
+    renderBottomNav(store);
+
+    expect(getTabButton("Rules")).toHaveAttribute("aria-current", "page");
+    expect(getTabButton("Settings")).not.toHaveAttribute("aria-current");
+  });
+
+  it("settings 뷰일 때 Settings 탭이 활성화된다", () => {
+    const store = createStore();
+    store.set(viewAtom, "settings");
+    renderBottomNav(store);
+
+    expect(getTabButton("Settings")).toHaveAttribute("aria-current", "page");
+    expect(getTabButton("Rules")).not.toHaveAttribute("aria-current");
+  });
+
+  it("editor 뷰일 때 Rules 탭이 활성화된다", () => {
+    const store = createStore();
+    store.set(viewAtom, "editor");
+    renderBottomNav(store);
+
+    expect(getTabButton("Rules")).toHaveAttribute("aria-current", "page");
+    expect(getTabButton("Settings")).not.toHaveAttribute("aria-current");
+  });
+
+  it("Rules 탭 클릭 시 dashboard 뷰로 전환한다", () => {
+    const store = createStore();
+    store.set(viewAtom, "settings");
+    renderBottomNav(store);
+
+    fireEvent.click(screen.getByText("Rules"));
+    expect(store.get(viewAtom)).toBe("dashboard");
+  });
+
+  it("Settings 탭 클릭 시 settings 뷰로 전환한다", () => {
+    const store = createStore();
+    store.set(viewAtom, "dashboard");
+    renderBottomNav(store);
+
+    fireEvent.click(screen.getByText("Settings"));
+    expect(store.get(viewAtom)).toBe("settings");
+  });
+
+  it("nav 요소로 렌더링된다", () => {
+    const store = createStore();
+    renderBottomNav(store);
+
+    expect(screen.getByRole("navigation")).toBeInTheDocument();
+  });
+});

--- a/src/test/setup.ts
+++ b/src/test/setup.ts
@@ -1,2 +1,17 @@
 import "fake-indexeddb/auto";
 import "@testing-library/jest-dom/vitest";
+import { vi } from "vitest";
+
+Object.defineProperty(window, "matchMedia", {
+  writable: true,
+  value: vi.fn().mockImplementation((query: string) => ({
+    matches: false,
+    media: query,
+    onchange: null,
+    addListener: vi.fn(),
+    removeListener: vi.fn(),
+    addEventListener: vi.fn(),
+    removeEventListener: vi.fn(),
+    dispatchEvent: vi.fn(),
+  })),
+});


### PR DESCRIPTION
## 개요

- BottomNav가 콘텐츠 길이에 따라 밀려나는 문제를 수정하여 항상 화면 하단에 고정되도록 변경
- 활성 탭에 `aria-current="page"` 속성을 추가하여 스크린 리더 접근성 향상
- AppShell, BottomNav 컴포넌트 단위 테스트 추가

## 변경 내용

- **AppShell**: 컨테이너 `min-h-screen` → `h-screen` 변경으로 flex 레이아웃에서 BottomNav 하단 고정
- **BottomNav**: 활성 탭에 `aria-current="page"` 속성 추가
- **테스트 setup**: `window.matchMedia` 전역 모킹 추가 (`useTheme` 등에서 사용)
- **AppShell 테스트**: 레이아웃 구조, h-screen 적용, 뷰 렌더링 검증
- **BottomNav 테스트**: 탭 렌더링, 활성 상태, 뷰 전환, aria-current 검증

## 테스트 계획

- [x] `npx vitest run src/components/__tests__/AppShell.test.tsx` 통과 확인
- [x] `npx vitest run src/components/__tests__/BottomNav.test.tsx` 통과 확인
- [x] Electron 개발 모드에서 BottomNav 하단 고정 확인
- [x] 콘텐츠가 길어도 BottomNav가 밀려나지 않는지 확인