### PR TITLE
feat(docs): homepage에 How to Use 및 Use Cases 섹션 추가

### DIFF
--- a/packages/docs/src/index.html
+++ b/packages/docs/src/index.html
@@ -281,6 +281,213 @@
       </div>
     </section>
 
+    <!-- How to Use -->
+    <section class="px-4 py-20 sm:py-28">
+      <div class="mx-auto max-w-5xl">
+        <h2
+          class="mb-4 text-center text-3xl font-bold tracking-tight sm:text-4xl"
+        >
+          How to Use
+        </h2>
+        <p
+          class="mx-auto mb-12 max-w-2xl text-center text-gray-600 sm:mb-16 dark:text-gray-400"
+        >
+          Set up your first alarm rule in four simple steps
+        </p>
+        <div class="grid gap-6 sm:grid-cols-2 lg:grid-cols-4">
+          <!-- Step 1 -->
+          <div
+            class="relative rounded-2xl border border-gray-200 bg-gray-50 p-6 transition hover:shadow-md dark:border-gray-800 dark:bg-gray-900"
+          >
+            <div
+              class="bg-tomato-600 mb-4 flex h-10 w-10 items-center justify-center rounded-full text-lg font-bold text-white"
+            >
+              1
+            </div>
+            <h3 class="mb-2 text-lg font-semibold">Create a Rule</h3>
+            <p class="text-sm text-gray-600 dark:text-gray-400">
+              Give your alarm rule a name to get started
+            </p>
+          </div>
+          <!-- Step 2 -->
+          <div
+            class="relative rounded-2xl border border-gray-200 bg-gray-50 p-6 transition hover:shadow-md dark:border-gray-800 dark:bg-gray-900"
+          >
+            <div
+              class="bg-tomato-600 mb-4 flex h-10 w-10 items-center justify-center rounded-full text-lg font-bold text-white"
+            >
+              2
+            </div>
+            <h3 class="mb-2 text-lg font-semibold">Add Triggers</h3>
+            <p class="text-sm text-gray-600 dark:text-gray-400">
+              Choose interval (e.g. every 15 min) or specific time (e.g. 2:30
+              PM)
+            </p>
+          </div>
+          <!-- Step 3 -->
+          <div
+            class="relative rounded-2xl border border-gray-200 bg-gray-50 p-6 transition hover:shadow-md dark:border-gray-800 dark:bg-gray-900"
+          >
+            <div
+              class="bg-tomato-600 mb-4 flex h-10 w-10 items-center justify-center rounded-full text-lg font-bold text-white"
+            >
+              3
+            </div>
+            <h3 class="mb-2 text-lg font-semibold">Set Filters (Optional)</h3>
+            <p class="text-sm text-gray-600 dark:text-gray-400">
+              Restrict when alarms fire with time ranges (e.g. 9 AM - 5 PM
+              only)
+            </p>
+          </div>
+          <!-- Step 4 -->
+          <div
+            class="relative rounded-2xl border border-gray-200 bg-gray-50 p-6 transition hover:shadow-md dark:border-gray-800 dark:bg-gray-900"
+          >
+            <div
+              class="bg-tomato-600 mb-4 flex h-10 w-10 items-center justify-center rounded-full text-lg font-bold text-white"
+            >
+              4
+            </div>
+            <h3 class="mb-2 text-lg font-semibold">Enable & Go</h3>
+            <p class="text-sm text-gray-600 dark:text-gray-400">
+              Toggle the rule on — alarms run in the background, even when
+              minimized
+            </p>
+          </div>
+        </div>
+      </div>
+    </section>
+
+    <!-- Use Cases -->
+    <section class="bg-gray-50 px-4 py-20 sm:py-28 dark:bg-gray-900/50">
+      <div class="mx-auto max-w-5xl">
+        <h2
+          class="mb-4 text-center text-3xl font-bold tracking-tight sm:text-4xl"
+        >
+          Use Cases
+        </h2>
+        <p
+          class="mx-auto mb-12 max-w-2xl text-center text-gray-600 sm:mb-16 dark:text-gray-400"
+        >
+          See how others use Tomato Mien to stay on track
+        </p>
+        <div class="grid gap-6 sm:grid-cols-2 lg:grid-cols-3">
+          <!-- Focus Timer -->
+          <div
+            class="rounded-2xl border border-gray-200 bg-white p-6 transition hover:shadow-md dark:border-gray-800 dark:bg-gray-900"
+          >
+            <div class="mb-3 text-3xl">🍅</div>
+            <h3 class="mb-2 text-lg font-semibold">Focus Timer</h3>
+            <div class="mb-3 flex flex-wrap gap-2">
+              <span
+                class="bg-tomato-100 text-tomato-700 dark:bg-tomato-900/30 dark:text-tomato-400 rounded-full px-2.5 py-0.5 text-xs font-medium"
+                >Every 25 min</span
+              >
+              <span
+                class="rounded-full bg-blue-100 px-2.5 py-0.5 text-xs font-medium text-blue-700 dark:bg-blue-900/30 dark:text-blue-400"
+                >9 AM - 6 PM</span
+              >
+            </div>
+            <p class="text-sm text-gray-600 dark:text-gray-400">
+              Stay productive with regular break reminders during work hours
+            </p>
+          </div>
+          <!-- Hydration Reminder -->
+          <div
+            class="rounded-2xl border border-gray-200 bg-white p-6 transition hover:shadow-md dark:border-gray-800 dark:bg-gray-900"
+          >
+            <div class="mb-3 text-3xl">💧</div>
+            <h3 class="mb-2 text-lg font-semibold">Hydration Reminder</h3>
+            <div class="mb-3 flex flex-wrap gap-2">
+              <span
+                class="bg-tomato-100 text-tomato-700 dark:bg-tomato-900/30 dark:text-tomato-400 rounded-full px-2.5 py-0.5 text-xs font-medium"
+                >Every 30 min</span
+              >
+              <span
+                class="rounded-full bg-blue-100 px-2.5 py-0.5 text-xs font-medium text-blue-700 dark:bg-blue-900/30 dark:text-blue-400"
+                >9 AM - 6 PM</span
+              >
+            </div>
+            <p class="text-sm text-gray-600 dark:text-gray-400">
+              Never forget to drink water throughout the day
+            </p>
+          </div>
+          <!-- Meeting Prep -->
+          <div
+            class="rounded-2xl border border-gray-200 bg-white p-6 transition hover:shadow-md dark:border-gray-800 dark:bg-gray-900"
+          >
+            <div class="mb-3 text-3xl">📋</div>
+            <h3 class="mb-2 text-lg font-semibold">Meeting Prep</h3>
+            <div class="mb-3 flex flex-wrap gap-2">
+              <span
+                class="bg-tomato-100 text-tomato-700 dark:bg-tomato-900/30 dark:text-tomato-400 rounded-full px-2.5 py-0.5 text-xs font-medium"
+                >At 2:25 PM</span
+              >
+            </div>
+            <p class="text-sm text-gray-600 dark:text-gray-400">
+              Get a heads-up 5 minutes before your daily standup
+            </p>
+          </div>
+          <!-- Hourly Stretch -->
+          <div
+            class="rounded-2xl border border-gray-200 bg-white p-6 transition hover:shadow-md dark:border-gray-800 dark:bg-gray-900"
+          >
+            <div class="mb-3 text-3xl">🧘</div>
+            <h3 class="mb-2 text-lg font-semibold">Hourly Stretch</h3>
+            <div class="mb-3 flex flex-wrap gap-2">
+              <span
+                class="bg-tomato-100 text-tomato-700 dark:bg-tomato-900/30 dark:text-tomato-400 rounded-full px-2.5 py-0.5 text-xs font-medium"
+                >Every 60 min</span
+              >
+              <span
+                class="rounded-full bg-blue-100 px-2.5 py-0.5 text-xs font-medium text-blue-700 dark:bg-blue-900/30 dark:text-blue-400"
+                >9 AM - 5 PM</span
+              >
+            </div>
+            <p class="text-sm text-gray-600 dark:text-gray-400">
+              Remind yourself to stand up and stretch every hour
+            </p>
+          </div>
+          <!-- Medication Alert -->
+          <div
+            class="rounded-2xl border border-gray-200 bg-white p-6 transition hover:shadow-md dark:border-gray-800 dark:bg-gray-900"
+          >
+            <div class="mb-3 text-3xl">💊</div>
+            <h3 class="mb-2 text-lg font-semibold">Medication Alert</h3>
+            <div class="mb-3 flex flex-wrap gap-2">
+              <span
+                class="bg-tomato-100 text-tomato-700 dark:bg-tomato-900/30 dark:text-tomato-400 rounded-full px-2.5 py-0.5 text-xs font-medium"
+                >At 8:00 AM, 8:00 PM</span
+              >
+            </div>
+            <p class="text-sm text-gray-600 dark:text-gray-400">
+              Never miss your morning and evening medication
+            </p>
+          </div>
+          <!-- Night Study Timer -->
+          <div
+            class="rounded-2xl border border-gray-200 bg-white p-6 transition hover:shadow-md dark:border-gray-800 dark:bg-gray-900"
+          >
+            <div class="mb-3 text-3xl">🌙</div>
+            <h3 class="mb-2 text-lg font-semibold">Night Study Timer</h3>
+            <div class="mb-3 flex flex-wrap gap-2">
+              <span
+                class="bg-tomato-100 text-tomato-700 dark:bg-tomato-900/30 dark:text-tomato-400 rounded-full px-2.5 py-0.5 text-xs font-medium"
+                >Every 20 min</span
+              >
+              <span
+                class="rounded-full bg-blue-100 px-2.5 py-0.5 text-xs font-medium text-blue-700 dark:bg-blue-900/30 dark:text-blue-400"
+                >10 PM - 2 AM</span
+              >
+            </div>
+            <p class="text-sm text-gray-600 dark:text-gray-400">
+              Track study sessions during late-night hours
+            </p>
+          </div>
+        </div>
+      </div>
+    </section>
+
     <!-- Installation -->
     <section class="px-4 py-20 sm:py-28">
       <div class="mx-auto max-w-5xl">


### PR DESCRIPTION
## 개요

- 홈페이지에 **How to Use** 및 **Use Cases** 두 개의 새 섹션 추가
- 방문자가 제품의 사용 방법과 구체적인 활용 사례를 빠르게 이해할 수 있도록 개선

## 변경 내용

### How to Use 섹션
- Screenshots와 Installation 사이에 4단계 스텝 가이드 삽입
- 각 스텝에 번호 배지 + 제목 + 설명 포함
- 데스크톱 4열, 모바일 세로 스택 반응형 레이아웃

### Use Cases 섹션
- 6개 활용 사례를 2×3 그리드 카드로 구성
- 트리거(tomato 색상)와 필터(blue 색상) 태그로 기능 연결 시각화
- Focus Timer, Hydration Reminder, Meeting Prep, Hourly Stretch, Medication Alert, Night Study Timer

### 공통
- 기존 Tailwind CSS 패턴 및 tomato 색상 테마 유지
- 다크 모드 지원
- 배경색 교대 패턴 유지 (How to Use: 흰색, Use Cases: gray-50)

## 테스트 계획

- [x] `npm run build` 빌드 성공 확인
- [x] 데스크톱 라이트/다크 모드 시각적 확인
- [x] 모바일(375px) 반응형 레이아웃 확인