### PR TITLE
fix: macOS에서 메인 윈도우 닫으면 앱 종료되도록 변경

### DIFF
--- a/electron/main.js
+++ b/electron/main.js
@@ -122,11 +122,9 @@ app.whenReady().then(() => {
   }
 });
 
-// 모든 윈도우가 닫혔을 때 앱 종료 (macOS 제외)
+// 모든 윈도우가 닫혔을 때 앱 종료 (싱글 윈도우 앱이므로 macOS 포함)
 app.on("window-all-closed", () => {
-  if (process.platform !== "darwin") {
-    app.quit();
-  }
+  app.quit();
 });
 
 // 알림 IPC 설정


### PR DESCRIPTION
## 개요

싱글 윈도우 앱에서 메인 윈도우를 닫아도 앱이 Dock에 남아있는 문제 수정.
App Store Review Guideline 4 (Design) 대응.

## 변경 내용

- `window-all-closed` 이벤트 핸들러에서 `process.platform !== "darwin"` 조건 제거
- macOS 포함 모든 플랫폼에서 윈도우 닫기 시 `app.quit()` 호출

## 테스트 계획

- [x] `npm run electron:build` 로컬 빌드
- [x] 메인 윈도우를 닫으면 앱이 종료되는지 확인
- [x] Dock에서 앱이 남아있지 않는지 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)