### PR TITLE
fix: 프로덕션 메뉴 정리 및 About 메뉴 네비게이션 연결

### DIFF
--- a/electron/main.js
+++ b/electron/main.js
@@ -199,7 +199,9 @@ function createMenu() {
       submenu: [
         { role: "reload", label: "Reload" },
         { role: "forceReload", label: "Force Reload" },
-        { role: "toggleDevTools", label: "Developer Tools" },
+        ...(isDev
+          ? [{ role: "toggleDevTools", label: "Developer Tools" }]
+          : []),
         { type: "separator" },
         { role: "resetZoom", label: "Actual Size" },
         { role: "zoomIn", label: "Zoom In" },

--- a/src/components/Settings/SettingsView.tsx
+++ b/src/components/Settings/SettingsView.tsx
@@ -1,6 +1,6 @@
-import { useState } from "react";
+import { useEffect } from "react";
 import { useAtom } from "jotai";
-import { settingsAtom } from "@/store";
+import { settingsAtom, settingsSubViewAtom } from "@/store";
 import type { TimeFormat, Theme } from "@/types/alarm";
 import {
   Card,
@@ -27,7 +27,11 @@ const themeOptions = [
 
 export function SettingsView() {
   const [settings, setSettings] = useAtom(settingsAtom);
-  const [subView, setSubView] = useState<"main" | "about">("main");
+  const [subView, setSubView] = useAtom(settingsSubViewAtom);
+
+  useEffect(() => {
+    return () => setSubView("main");
+  }, [setSubView]);
 
   const handleTimeFormatChange = (value: string) => {
     setSettings({ ...settings, timeFormat: value as TimeFormat });

--- a/src/hooks/useElectronMenu.ts
+++ b/src/hooks/useElectronMenu.ts
@@ -1,11 +1,17 @@
 import { useEffect } from "react";
 import { useSetAtom } from "jotai";
-import { addRuleAtom, enableAllRulesAtom, disableAllRulesAtom } from "@/store";
+import {
+  addRuleAtom,
+  enableAllRulesAtom,
+  disableAllRulesAtom,
+  navigateToAboutAtom,
+} from "@/store";
 
 export function useElectronMenu() {
   const addRule = useSetAtom(addRuleAtom);
   const enableAll = useSetAtom(enableAllRulesAtom);
   const disableAll = useSetAtom(disableAllRulesAtom);
+  const navigateToAbout = useSetAtom(navigateToAboutAtom);
 
   useEffect(() => {
     const api = window.electronAPI;
@@ -26,11 +32,14 @@ export function useElectronMenu() {
             disableAll();
           }
           break;
+        case "menu-about":
+          navigateToAbout();
+          break;
       }
     });
 
     return () => {
       api.removeMenuListeners();
     };
-  }, [addRule, enableAll, disableAll]);
+  }, [addRule, enableAll, disableAll, navigateToAbout]);
 }

--- a/src/store/actions.ts
+++ b/src/store/actions.ts
@@ -1,5 +1,10 @@
 import { atom } from "jotai";
-import { rulesAtom, viewAtom, editorRuleIdAtom } from "./atoms";
+import {
+  rulesAtom,
+  viewAtom,
+  editorRuleIdAtom,
+  settingsSubViewAtom,
+} from "./atoms";
 import type { AlarmRule } from "@/types/alarm";
 import { createDefaultInterval } from "@/utils/alarmRules";
 
@@ -72,4 +77,9 @@ export const disableAllRulesAtom = atom(null, (get, set) => {
     rulesAtom,
     get(rulesAtom).map(r => ({ ...r, enabled: false })),
   );
+});
+
+export const navigateToAboutAtom = atom(null, (_get, set) => {
+  set(viewAtom, "settings");
+  set(settingsSubViewAtom, "about");
 });

--- a/src/store/atoms.ts
+++ b/src/store/atoms.ts
@@ -31,6 +31,10 @@ export const editorRuleIdAtom = atom<string | null>(null);
 
 export const searchQueryAtom = atom("");
 
+export type SettingsSubView = "main" | "about";
+
+export const settingsSubViewAtom = atom<SettingsSubView>("main");
+
 export type SortOrder = "name" | "recent";
 
 export const sortOrderAtom = atom<SortOrder>("recent");

--- a/src/store/index.ts
+++ b/src/store/index.ts
@@ -5,8 +5,9 @@ export {
   searchQueryAtom,
   sortOrderAtom,
   settingsAtom,
+  settingsSubViewAtom,
 } from "./atoms";
-export type { ViewState, SortOrder } from "./atoms";
+export type { ViewState, SortOrder, SettingsSubView } from "./atoms";
 
 export {
   activeRuleCountAtom,
@@ -21,4 +22,5 @@ export {
   toggleRuleAtom,
   enableAllRulesAtom,
   disableAllRulesAtom,
+  navigateToAboutAtom,
 } from "./actions";


### PR DESCRIPTION
## 개요

- 프로덕션 빌드에서 View > Developer Tools 메뉴 항목을 숨김
- Help > About Tomato Mien 메뉴 클릭 시 Settings > About 화면으로 이동하도록 연결

## 변경 내용

### 1. Developer Tools 메뉴 숨기기
- `electron/main.js`: `isDev` 조건부 스프레드로 프로덕션에서 `toggleDevTools` 제외

### 2. About 메뉴 네비게이션
- `src/store/atoms.ts`: `settingsSubViewAtom` 추가 (`"main" | "about"`)
- `src/store/actions.ts`: `navigateToAboutAtom` 액션 아톰 추가 (Jotai write 트랜잭션으로 배칭 보장)
- `src/components/Settings/SettingsView.tsx`: 로컬 `useState` → `settingsSubViewAtom`으로 전환, 언마운트 시 `"main"`으로 리셋
- `src/hooks/useElectronMenu.ts`: `menu-about` 핸들링 추가

### 3. 테스트 보강
- `menu-new-rule` 테스트 추가 (규칙 생성 + editor 뷰 이동)
- `menu-about` 테스트 2건 (기본 + 이미 settings 뷰일 때)
- cleanup 테스트 (언마운트 시 `removeMenuListeners` 호출)
- 브라우저 폴백 테스트 (`electronAPI` 없을 때 에러 없이 동작)

## 테스트 계획

- [x] `useElectronMenu` 전체 메뉴 액션 테스트 통과 (9건)
- [x] 전체 테스트 스위트 통과 (27파일, 262건)
- [x] Electron 개발 모드에서 Developer Tools 메뉴 표시 확인
- [x] Electron 프로덕션 빌드에서 Developer Tools 메뉴 미표시 확인
- [x] Help > About Tomato Mien 클릭 시 About 화면 이동 확인