### PR TITLE
feat: View Transition 개선 — drill/slide 애니메이션 및 패키지 분리

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -7,6 +7,7 @@
     "": {
       "name": "tomato-mien",
       "version": "2.1.1",
+      "license": "MIT",
       "workspaces": [
         "packages/*"
       ],
@@ -59,6 +60,10 @@
         "vitest": "^4.0.18",
         "wait-on": "^9.0.1",
         "zod": "^4.3.6"
+      },
+      "funding": {
+        "type": "individual",
+        "url": "https://tomato-mien.lemonsqueezy.com/checkout/buy/5457327e-10c4-449a-b3c0-e63264a89720?discount=0"
       }
     },
     "node_modules/@acemir/cssom": {
@@ -3106,6 +3111,10 @@
     },
     "node_modules/@tomato-mien/ui": {
       "resolved": "packages/ui",
+      "link": true
+    },
+    "node_modules/@tomato-mien/view-transition": {
+      "resolved": "packages/view-transition",
       "link": true
     },
     "node_modules/@types/aria-query": {
@@ -13117,6 +13126,13 @@
         "clsx": "^2.0.0",
         "react": "^19.0.0",
         "tailwind-merge": "^3.0.0"
+      }
+    },
+    "packages/view-transition": {
+      "name": "@tomato-mien/view-transition",
+      "version": "0.1.0",
+      "peerDependencies": {
+        "react": "^19.0.0"
       }
     }
   }

--- a/packages/view-transition/package.json
+++ b/packages/view-transition/package.json
@@ -1,0 +1,15 @@
+{
+  "name": "@tomato-mien/view-transition",
+  "version": "0.1.0",
+  "private": true,
+  "type": "module",
+  "exports": {
+    ".": "./src/index.ts",
+    "./transitions.css": "./src/transitions.css"
+  },
+  "files": ["src/"],
+  "peerDependencies": {
+    "react": "^19.0.0",
+    "react-dom": "^19.0.0"
+  }
+}

--- a/packages/view-transition/src/index.ts
+++ b/packages/view-transition/src/index.ts
@@ -1,0 +1,6 @@
+export {
+  useViewTransition,
+  useViewTransitionList,
+  usePrefersReducedMotion,
+} from "./useViewTransition.ts";
+export type { TransitionDirection } from "./useViewTransition.ts";

--- a/packages/view-transition/src/transitions.css
+++ b/packages/view-transition/src/transitions.css
@@ -1,0 +1,125 @@
+/* ── View Transition: merge individual cards into root during drill ── */
+
+html[data-transition-direction] .vt-merge-root {
+  view-transition-name: none !important;
+}
+
+/* ── View Transition: Drill Animation ── */
+
+@keyframes drill-slide-out-left {
+  from {
+    transform: translate3d(0, 0, 0);
+  }
+  to {
+    transform: translate3d(-20%, 0, 0);
+  }
+}
+
+@keyframes drill-slide-in-from-right {
+  from {
+    transform: translate3d(100%, 0, 0);
+  }
+  to {
+    transform: translate3d(0, 0, 0);
+  }
+}
+
+@keyframes drill-slide-out-right {
+  from {
+    transform: translate3d(0, 0, 0);
+  }
+  to {
+    transform: translate3d(100%, 0, 0);
+  }
+}
+
+@keyframes drill-slide-in-from-left {
+  from {
+    transform: translate3d(-20%, 0, 0);
+  }
+  to {
+    transform: translate3d(0, 0, 0);
+  }
+}
+
+/* Drill Forward: new page slides from right, old page pushes left */
+html[data-transition-direction="drill-forward"]::view-transition-old(root) {
+  animation: drill-slide-out-left 0.3s cubic-bezier(0.4, 0, 0.2, 1) both;
+  mix-blend-mode: normal;
+}
+
+html[data-transition-direction="drill-forward"]::view-transition-new(root) {
+  animation: drill-slide-in-from-right 0.3s cubic-bezier(0.4, 0, 0.2, 1) both;
+  mix-blend-mode: normal;
+}
+
+/* Drill Backward: old page slides right, new page enters from left */
+html[data-transition-direction="drill-backward"]::view-transition-old(root) {
+  animation: drill-slide-out-right 0.4s cubic-bezier(0.2, 0, 0, 1) both;
+  mix-blend-mode: normal;
+}
+
+html[data-transition-direction="drill-backward"]::view-transition-new(root) {
+  animation: drill-slide-in-from-left 0.4s cubic-bezier(0.2, 0, 0, 1) both;
+  mix-blend-mode: normal;
+}
+
+/* ── View Transition: Slide Animation ── */
+
+@keyframes slide-out-left {
+  from {
+    transform: translate3d(0, 0, 0);
+  }
+  to {
+    transform: translate3d(-100%, 0, 0);
+  }
+}
+
+@keyframes slide-in-from-right {
+  from {
+    transform: translate3d(100%, 0, 0);
+  }
+  to {
+    transform: translate3d(0, 0, 0);
+  }
+}
+
+@keyframes slide-out-right {
+  from {
+    transform: translate3d(0, 0, 0);
+  }
+  to {
+    transform: translate3d(100%, 0, 0);
+  }
+}
+
+@keyframes slide-in-from-left {
+  from {
+    transform: translate3d(-100%, 0, 0);
+  }
+  to {
+    transform: translate3d(0, 0, 0);
+  }
+}
+
+/* Slide Left: old page exits left, new page enters from right */
+html[data-transition-direction="slide-left"]::view-transition-old(root) {
+  animation: slide-out-left 0.3s cubic-bezier(0.4, 0, 0.2, 1) both;
+  mix-blend-mode: normal;
+}
+
+html[data-transition-direction="slide-left"]::view-transition-new(root) {
+  animation: slide-in-from-right 0.3s cubic-bezier(0.4, 0, 0.2, 1) both;
+  mix-blend-mode: normal;
+}
+
+/* Slide Right: old page exits right, new page enters from left */
+html[data-transition-direction="slide-right"]::view-transition-old(root) {
+  animation: slide-out-right 0.3s cubic-bezier(0.4, 0, 0.2, 1) both;
+  mix-blend-mode: normal;
+}
+
+html[data-transition-direction="slide-right"]::view-transition-new(root) {
+  animation: slide-in-from-left 0.3s cubic-bezier(0.4, 0, 0.2, 1) both;
+  mix-blend-mode: normal;
+}

--- a/packages/view-transition/tsconfig.json
+++ b/packages/view-transition/tsconfig.json
@@ -1,0 +1,15 @@
+{
+  "compilerOptions": {
+    "target": "ES2020",
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "jsx": "react-jsx",
+    "strict": true,
+    "declaration": true,
+    "allowImportingTsExtensions": true,
+    "noEmit": true,
+    "skipLibCheck": true,
+    "verbatimModuleSyntax": true
+  },
+  "include": ["src"]
+}

--- a/packages/view-transition/tsconfig.tsbuildinfo
+++ b/packages/view-transition/tsconfig.tsbuildinfo
@@ -1,0 +1,1 @@
+{"root":["./src/index.ts","./src/useviewtransition.ts"],"version":"5.9.3"}

--- a/src/components/Dashboard/DashboardHeader.tsx
+++ b/src/components/Dashboard/DashboardHeader.tsx
@@ -1,14 +1,19 @@
 import { useSetAtom } from "jotai";
 import { addRuleAtom } from "@/store";
 import { Button, AddIcon } from "@tomato-mien/ui";
+import { useViewTransition } from "@tomato-mien/view-transition";
 
 export function DashboardHeader() {
   const addRule = useSetAtom(addRuleAtom);
+  const { triggerTransition } = useViewTransition();
 
   return (
     <div className="flex items-center justify-between px-5 pt-6 pb-2">
       <h1 className="text-heading-1 text-foreground">Rules</h1>
-      <Button onClick={() => addRule()} className="gap-1">
+      <Button
+        onClick={() => triggerTransition(() => addRule(), "drill-forward")}
+        className="gap-1"
+      >
         <AddIcon size="sm" className="text-white" />
         Create
       </Button>

--- a/src/components/Dashboard/RuleCard.tsx
+++ b/src/components/Dashboard/RuleCard.tsx
@@ -11,6 +11,7 @@ import { describeRule } from "@/utils/condition";
 import { Card, MenuRow, Toggle, TimerIcon, AlarmIcon } from "@tomato-mien/ui";
 import type { ComponentType } from "react";
 import type { IconProps } from "@tomato-mien/ui";
+import { useViewTransition } from "@tomato-mien/view-transition";
 
 function getConditionIcon(
   triggers: TriggerCondition[],
@@ -34,9 +35,17 @@ export function RuleCard({ rule }: RuleCardProps) {
   const setView = useSetAtom(viewAtom);
   const setEditorRuleId = useSetAtom(editorRuleIdAtom);
   const { timeFormat } = useAtomValue(settingsAtom);
+  const { triggerTransition } = useViewTransition();
 
   const description = describeRule(rule.triggers, rule.filters, timeFormat);
   const icon = getConditionIcon(rule.triggers);
+
+  const navigateToEditor = () => {
+    triggerTransition(() => {
+      setEditorRuleId(rule.id);
+      setView("editor");
+    }, "drill-forward");
+  };
 
   return (
     <Card
@@ -47,15 +56,11 @@ export function RuleCard({ rule }: RuleCardProps) {
       )}
       role="button"
       tabIndex={0}
-      onClick={() => {
-        setEditorRuleId(rule.id);
-        setView("editor");
-      }}
+      onClick={navigateToEditor}
       onKeyDown={e => {
         if (e.key === "Enter" || e.key === " ") {
           e.preventDefault();
-          setEditorRuleId(rule.id);
-          setView("editor");
+          navigateToEditor();
         }
       }}
     >

--- a/src/components/Dashboard/RuleCardList.tsx
+++ b/src/components/Dashboard/RuleCardList.tsx
@@ -1,6 +1,6 @@
 import { useAtomValue } from "jotai";
 import { filteredRulesAtom } from "@/store";
-import { useViewTransitionList } from "@/hooks/useViewTransition";
+import { useViewTransitionList } from "@tomato-mien/view-transition";
 import { RuleCard } from "./RuleCard";
 
 export function RuleCardList() {
@@ -23,6 +23,7 @@ export function RuleCardList() {
       {displayRules.map(rule => (
         <div
           key={rule.id}
+          className="vt-merge-root"
           style={{ viewTransitionName: `rule-card-${rule.id}` }}
         >
           <RuleCard rule={rule} />

--- a/src/components/Editor/EditorHeader.tsx
+++ b/src/components/Editor/EditorHeader.tsx
@@ -1,6 +1,7 @@
 import { useSetAtom } from "jotai";
 import { viewAtom } from "@/store";
 import { Button, ArrowBackIcon } from "@tomato-mien/ui";
+import { useViewTransition } from "@tomato-mien/view-transition";
 
 interface EditorHeaderProps {
   isNew: boolean;
@@ -8,12 +9,15 @@ interface EditorHeaderProps {
 
 export function EditorHeader({ isNew }: EditorHeaderProps) {
   const setView = useSetAtom(viewAtom);
+  const { triggerTransition } = useViewTransition();
 
   return (
     <div className="flex items-center gap-3 px-5 pt-6 pb-4">
       <Button
         variant="ghost"
-        onClick={() => setView("dashboard")}
+        onClick={() =>
+          triggerTransition(() => setView("dashboard"), "drill-backward")
+        }
         aria-label="Back to dashboard"
         className="h-9 w-9 p-0"
       >

--- a/src/components/Editor/EditorView.tsx
+++ b/src/components/Editor/EditorView.tsx
@@ -21,6 +21,7 @@ import { EditorSettings } from "./EditorSettings";
 import { EditorSummary } from "./EditorSummary";
 import { EditorFooter } from "./EditorFooter";
 import { Button, DeleteOutlineIcon } from "@tomato-mien/ui";
+import { useViewTransition } from "@tomato-mien/view-transition";
 
 export function EditorView() {
   const ruleId = useAtomValue(editorRuleIdAtom);
@@ -29,6 +30,7 @@ export function EditorView() {
   const deleteRule = useSetAtom(deleteRuleAtom);
   const setView = useSetAtom(viewAtom);
   const setEditorRuleId = useSetAtom(editorRuleIdAtom);
+  const { triggerTransition } = useViewTransition();
   const existingRule = ruleId ? rules.find(r => r.id === ruleId) : undefined;
   const isNew = !existingRule;
 
@@ -87,19 +89,23 @@ export function EditorView() {
       notificationEnabled,
       activatedAt: existingRule?.activatedAt ?? now,
     };
-    updateRule(updated);
-    setEditorRuleId(null);
-    setView("dashboard");
+    triggerTransition(() => {
+      updateRule(updated);
+      setEditorRuleId(null);
+      setView("dashboard");
+    }, "drill-backward");
   };
 
   const handleCancel = () => {
-    setEditorRuleId(null);
-    setView("dashboard");
+    triggerTransition(() => {
+      setEditorRuleId(null);
+      setView("dashboard");
+    }, "drill-backward");
   };
 
   const handleDelete = () => {
     if (ruleId && window.confirm("Delete this rule?")) {
-      deleteRule(ruleId);
+      triggerTransition(() => deleteRule(ruleId), "drill-backward");
     }
   };
 

--- a/src/components/Layout/BottomNav.tsx
+++ b/src/components/Layout/BottomNav.tsx
@@ -5,6 +5,21 @@ import type { ViewState } from "@/store";
 import { RuleIcon, SettingsIcon } from "@tomato-mien/ui";
 import type { ComponentType } from "react";
 import type { IconProps } from "@tomato-mien/ui";
+import {
+  useViewTransition,
+  type TransitionDirection,
+} from "@tomato-mien/view-transition";
+
+function getTabDirection(
+  from: ViewState,
+  to: ViewState,
+): TransitionDirection | undefined {
+  if (from === "editor" && to === "dashboard") return "drill-backward";
+  if (from === "editor") return undefined; // editor → settings: plain crossfade
+  if (to === "settings") return "slide-left";
+  if (to === "dashboard") return "slide-right";
+  return undefined;
+}
 
 const tabs = [
   { id: "dashboard", icon: RuleIcon, label: "Rules" },
@@ -20,6 +35,7 @@ function getActiveTab(view: ViewState): TabId {
 
 export function BottomNav() {
   const [view, setView] = useAtom(viewAtom);
+  const { triggerTransition } = useViewTransition();
   const currentTab = getActiveTab(view);
 
   return (
@@ -33,11 +49,11 @@ export function BottomNav() {
             key={tab.id}
             aria-current={isActive ? "page" : undefined}
             onClick={() => {
-              if (tab.id === "dashboard") {
-                setView("dashboard");
-              } else if (tab.id === "settings") {
-                setView("settings");
-              }
+              const target: ViewState =
+                tab.id === "dashboard" ? "dashboard" : "settings";
+              if (view === target) return;
+              const direction = getTabDirection(view, target);
+              triggerTransition(() => setView(target), direction);
             }}
             className={cn(
               "focus-visible:ring-ring text-caption flex flex-1 flex-col items-center gap-0.5 py-2 font-medium transition-colors focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:outline-none",

--- a/src/components/Settings/SettingsView.tsx
+++ b/src/components/Settings/SettingsView.tsx
@@ -13,6 +13,7 @@ import {
 } from "@tomato-mien/ui";
 import { formatTime, formatTimeRange } from "@/lib/dayjs";
 import { AboutView } from "./AboutView";
+import { useViewTransition } from "@tomato-mien/view-transition";
 
 const timeFormatOptions = [
   { value: "24h", label: "24-hour" },
@@ -28,6 +29,7 @@ const themeOptions = [
 export function SettingsView() {
   const [settings, setSettings] = useAtom(settingsAtom);
   const [subView, setSubView] = useAtom(settingsSubViewAtom);
+  const { triggerTransition } = useViewTransition();
 
   useEffect(() => {
     return () => setSubView("main");
@@ -42,7 +44,13 @@ export function SettingsView() {
   };
 
   if (subView === "about") {
-    return <AboutView onBack={() => setSubView("main")} />;
+    return (
+      <AboutView
+        onBack={() =>
+          triggerTransition(() => setSubView("main"), "drill-backward")
+        }
+      />
+    );
   }
 
   return (
@@ -107,7 +115,9 @@ export function SettingsView() {
             as="button"
             type="button"
             className="focus-visible:ring-ring w-full cursor-pointer rounded-xl transition-shadow hover:shadow-md focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:outline-none"
-            onClick={() => setSubView("about")}
+            onClick={() =>
+              triggerTransition(() => setSubView("about"), "drill-forward")
+            }
           >
             <MenuRow.Icon icon={InfoIcon} />
             <MenuRow.Label

--- a/src/hooks/__tests__/useViewTransition.test.ts
+++ b/src/hooks/__tests__/useViewTransition.test.ts
@@ -4,7 +4,7 @@ import {
   usePrefersReducedMotion,
   useViewTransition,
   useViewTransitionList,
-} from "@/hooks/useViewTransition";
+} from "@tomato-mien/view-transition";
 
 function createMockMatchMedia(matches: boolean) {
   const listeners: Array<(e: MediaQueryListEvent) => void> = [];

--- a/src/hooks/index.ts
+++ b/src/hooks/index.ts
@@ -4,4 +4,4 @@ export {
   usePrefersReducedMotion,
   useViewTransition,
   useViewTransitionList,
-} from "./useViewTransition";
+} from "@tomato-mien/view-transition";

--- a/src/hooks/useElectronMenu.ts
+++ b/src/hooks/useElectronMenu.ts
@@ -6,12 +6,14 @@ import {
   disableAllRulesAtom,
   navigateToAboutAtom,
 } from "@/store";
+import { useViewTransition } from "@tomato-mien/view-transition";
 
 export function useElectronMenu() {
   const addRule = useSetAtom(addRuleAtom);
   const enableAll = useSetAtom(enableAllRulesAtom);
   const disableAll = useSetAtom(disableAllRulesAtom);
   const navigateToAbout = useSetAtom(navigateToAboutAtom);
+  const { triggerTransition } = useViewTransition();
 
   useEffect(() => {
     const api = window.electronAPI;
@@ -20,7 +22,7 @@ export function useElectronMenu() {
     api.onMenuAction((_event, action) => {
       switch (action) {
         case "menu-new-rule":
-          addRule();
+          triggerTransition(() => addRule(), "drill-forward");
           break;
         case "menu-enable-all-alarms":
           if (window.confirm("Enable all rules?")) {
@@ -33,7 +35,7 @@ export function useElectronMenu() {
           }
           break;
         case "menu-about":
-          navigateToAbout();
+          triggerTransition(() => navigateToAbout(), "drill-forward");
           break;
       }
     });
@@ -41,5 +43,5 @@ export function useElectronMenu() {
     return () => {
       api.removeMenuListeners();
     };
-  }, [addRule, enableAll, disableAll, navigateToAbout]);
+  }, [addRule, enableAll, disableAll, navigateToAbout, triggerTransition]);
 }

--- a/src/index.css
+++ b/src/index.css
@@ -1,5 +1,6 @@
 @import "tailwindcss";
 @import "@tomato-mien/design-tokens";
+@import "@tomato-mien/view-transition/transitions.css";
 @plugin "@tailwindcss/forms";
 @source "../packages/ui/src";
 
@@ -102,3 +103,4 @@ body {
   -webkit-font-smoothing: antialiased;
   -moz-osx-font-smoothing: grayscale;
 }
+

--- a/tsconfig.app.json
+++ b/tsconfig.app.json
@@ -29,7 +29,8 @@
     "paths": {
       "@/*": ["src/*"],
       "@assets/*": ["assets/*"],
-      "@tomato-mien/ui": ["packages/ui/src/index.ts"]
+      "@tomato-mien/ui": ["packages/ui/src/index.ts"],
+      "@tomato-mien/view-transition": ["packages/view-transition/src/index.ts"]
     }
   },
   "include": ["src"]

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -3,6 +3,7 @@
   "references": [
     { "path": "./tsconfig.app.json" },
     { "path": "./tsconfig.node.json" },
-    { "path": "./packages/ui" }
+    { "path": "./packages/ui" },
+    { "path": "./packages/view-transition" }
   ]
 }


### PR DESCRIPTION
## Summary

- backward drill 트랜지션 수정: `vt-merge-root` 클래스로 개별 `viewTransitionName`이 root 그룹에서 제외되는 문제 해결
- slide 트랜지션 추가: Dashboard ↔ Settings 탭 전환 시 `slide-left`/`slide-right` 애니메이션
- backward drill 타이밍 개선: `0.3s` → `0.4s`, 더 부드러운 감속 easing (`cubic-bezier(0.2, 0, 0, 1)`)
- `@tomato-mien/view-transition` 워크스페이스 패키지로 분리 (hook + CSS)
- 동시 트랜지션 간섭 방지: 방향성 트랜지션 진행 중 무방향 호출은 `startViewTransition` 없이 직접 DOM 업데이트
- 모듈 레벨 `activeTransition` 싱글톤으로 여러 hook 인스턴스 간 경합 방지

## Changes

### Phase 1: Backward drill 수정
- `RuleCardList.tsx`: 카드 wrapper에 `className="vt-merge-root"` 추가
- `transitions.css`: `html[data-transition-direction] .vt-merge-root { view-transition-name: none !important }` 규칙 추가

### Phase 2: Slide 트랜지션 + Direction 리네이밍
- `TransitionDirection` 타입: `"forward" | "backward"` → `"drill-forward" | "drill-backward" | "slide-left" | "slide-right"`
- slide 키프레임 4개 + pseudo-element 규칙 4개 추가
- `BottomNav`에 `getTabDirection()` 함수로 탭 전환 방향 결정
- 8개 컴포넌트/훅 파일에서 direction 값 리네이밍

### Phase 3: Backward drill 타이밍 개선
- `drill-backward` duration `0.3s` → `0.4s`, easing `cubic-bezier(0.2, 0, 0, 1)`

### Phase 4: 패키지 분리
- `packages/view-transition/` 생성 (`package.json`, `tsconfig.json`, `src/index.ts`, `src/useViewTransition.ts`, `src/transitions.css`)
- `src/hooks/useViewTransition.ts` 삭제 (패키지로 이동)
- 9개 파일에서 import 경로 `@/hooks/useViewTransition` → `@tomato-mien/view-transition`로 변경
- `tsconfig.json`, `tsconfig.app.json`에 패키지 참조 추가
- `src/index.css`에 `@import "@tomato-mien/view-transition/transitions.css"` 추가

## Test plan

- [x] `npx vitest run` — 265개 테스트 전체 통과
- [x] `npx tsc -b --noEmit` — TypeScript 타입 체크 통과
- [x] `npm run build` — 프로덕션 빌드 성공
- [x] Dashboard → Editor: drill-forward 애니메이션 확인
- [x] Editor → Dashboard: drill-backward 애니메이션 확인
- [x] Dashboard → Settings: slide-left 애니메이션 확인
- [x] Settings → Dashboard: slide-right 애니메이션 확인
- [x] Settings → About → Back: drill-forward/drill-backward 확인
- [x] `prefers-reduced-motion: reduce` 설정 시 애니메이션 스킵 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)