### PR TITLE
fix(ci): MAS 빌드 시 provisioning profile을 GitHub Secret에서 복원

### DIFF
--- a/.github/workflows/build-and-release.yml
+++ b/.github/workflows/build-and-release.yml
@@ -157,8 +157,11 @@ jobs:
           security list-keychain -d user -s $KEYCHAIN_PATH
 
       - name: Copy provisioning profile
+        env:
+          APPLE_PROVISIONING_PROFILE: ${{ secrets.APPLE_PROVISIONING_PROFILE }}
         run: |
           mkdir -p ~/Library/MobileDevice/Provisioning\ Profiles
+          echo -n "$APPLE_PROVISIONING_PROFILE" | base64 --decode -o electron/entitlements/embedded.provisionprofile
           cp electron/entitlements/embedded.provisionprofile ~/Library/MobileDevice/Provisioning\ Profiles/
 
       - name: Build MAS app


### PR DESCRIPTION
gitignore에 의해 embedded.provisionprofile이 저장소에 포함되지 않아 CI에서 파일을 찾지 못하는 문제를 수정한다.
APPLE_PROVISIONING_PROFILE secret에서 base64 디코딩하여 파일을 생성한다.