### PR TITLE
fix(ci): MAS 빌드 App Store Connect 업로드 수정

### DIFF
--- a/.github/workflows/build-and-release.yml
+++ b/.github/workflows/build-and-release.yml
@@ -167,17 +167,34 @@ jobs:
       - name: Build MAS app
         run: npm run electron:mas:dist
 
+      - name: Setup App Store Connect API Key
+        env:
+          APP_STORE_CONNECT_API_KEY_FILE: ${{ secrets.APP_STORE_CONNECT_API_KEY_FILE }}
+          APP_STORE_CONNECT_API_KEY: ${{ secrets.APP_STORE_CONNECT_API_KEY }}
+        run: |
+          mkdir -p ~/private_keys
+          echo -n "$APP_STORE_CONNECT_API_KEY_FILE" | base64 --decode -o ~/private_keys/AuthKey_${APP_STORE_CONNECT_API_KEY}.p8
+
       - name: Upload to App Store Connect
         run: |
+          PKG_FILE=$(ls release/mas/*.pkg 2>/dev/null | head -1)
+          if [ -z "$PKG_FILE" ]; then
+            echo "Error: No .pkg file found in release/mas/"
+            ls -la release/mas/ || echo "Directory release/mas/ does not exist"
+            exit 1
+          fi
+          echo "Uploading: $PKG_FILE"
           xcrun altool --upload-app \
             --type osx \
-            --file release/mas/*.pkg \
+            --file "$PKG_FILE" \
             --apiKey ${{ secrets.APP_STORE_CONNECT_API_KEY }} \
             --apiIssuer ${{ secrets.APP_STORE_CONNECT_API_ISSUER }}
 
       - name: Cleanup
         if: always()
-        run: security delete-keychain $RUNNER_TEMP/mas-signing.keychain-db || true
+        run: |
+          security delete-keychain $RUNNER_TEMP/mas-signing.keychain-db || true
+          rm -rf ~/private_keys || true
 
   release:
     needs: build


### PR DESCRIPTION
## Summary
- App Store Connect API Key(`.p8`) 파일을 GitHub Secret에서 복원하는 step 추가
- `altool`에 glob 패턴(`*.pkg`) 대신 실제 파일 경로를 전달하도록 수정
- Cleanup step에서 API Key 파일도 함께 삭제

## Test plan
- [x] `APP_STORE_CONNECT_API_KEY_FILE` Secret 추가 (`.p8` 파일 base64 인코딩)
- [x] `workflow_dispatch`로 build-mas 잡 실행하여 업로드 성공 확인