### PR TITLE
feat(docs): Download 버튼 OS 자동 감지 및 직접 다운로드 연결

### DIFF
--- a/packages/docs/src/index.html
+++ b/packages/docs/src/index.html
@@ -26,9 +26,23 @@
     <link rel="icon" type="image/png" sizes="16x16" href="assets/icon-16.png" />
     <link rel="icon" type="image/png" sizes="32x32" href="assets/icon-32.png" />
     <link rel="icon" type="image/png" sizes="64x64" href="assets/icon-64.png" />
-    <link rel="icon" type="image/png" sizes="128x128" href="assets/icon-128.png" />
-    <link rel="icon" type="image/png" sizes="256x256" href="assets/icon-256.png" />
-    <link rel="apple-touch-icon" sizes="180x180" href="assets/icon-rounded.png" />
+    <link
+      rel="icon"
+      type="image/png"
+      sizes="128x128"
+      href="assets/icon-128.png"
+    />
+    <link
+      rel="icon"
+      type="image/png"
+      sizes="256x256"
+      href="assets/icon-256.png"
+    />
+    <link
+      rel="apple-touch-icon"
+      sizes="180x180"
+      href="assets/icon-rounded.png"
+    />
     <link rel="stylesheet" href="styles.css" />
   </head>
   <body
@@ -57,36 +71,46 @@
         >
           Simple Rule-Based Alarm App
         </p>
-        <div class="flex flex-col gap-4 sm:flex-row">
-          <a
-            href="https://github.com/Einere/tomato-mien/releases/latest"
-            class="bg-tomato-600 hover:bg-tomato-700 inline-flex items-center gap-2 rounded-xl px-8 py-3 text-lg font-semibold text-white shadow-lg transition hover:shadow-xl"
-          >
-            <svg
-              class="h-5 w-5"
-              fill="none"
-              stroke="currentColor"
-              stroke-width="2"
-              viewBox="0 0 24 24"
+        <div id="hero-download" class="flex flex-col items-center gap-3">
+          <div class="flex flex-col gap-4 sm:flex-row">
+            <a
+              id="hero-download-btn"
+              href="https://github.com/Einere/tomato-mien/releases/latest"
+              class="bg-tomato-600 hover:bg-tomato-700 inline-flex items-center gap-2 rounded-xl px-8 py-3 text-lg font-semibold text-white shadow-lg transition hover:shadow-xl"
             >
-              <path
-                stroke-linecap="round"
-                stroke-linejoin="round"
-                d="M4 16v2a2 2 0 002 2h12a2 2 0 002-2v-2M7 10l5 5 5-5M12 15V3"
-              />
-            </svg>
-            Download
-          </a>
+              <svg
+                class="h-5 w-5"
+                fill="none"
+                stroke="currentColor"
+                stroke-width="2"
+                viewBox="0 0 24 24"
+              >
+                <path
+                  stroke-linecap="round"
+                  stroke-linejoin="round"
+                  d="M4 16v2a2 2 0 002 2h12a2 2 0 002-2v-2M7 10l5 5 5-5M12 15V3"
+                />
+              </svg>
+              <span id="hero-download-label">Download</span>
+            </a>
+            <a
+              href="https://github.com/Einere/tomato-mien"
+              class="inline-flex items-center gap-2 rounded-xl border border-gray-300 px-8 py-3 text-lg font-semibold transition hover:border-gray-400 hover:bg-gray-50 dark:border-gray-700 dark:hover:border-gray-600 dark:hover:bg-gray-900"
+            >
+              <svg class="h-5 w-5" fill="currentColor" viewBox="0 0 24 24">
+                <path
+                  d="M12 0C5.37 0 0 5.37 0 12c0 5.31 3.435 9.795 8.205 11.385.6.105.825-.255.825-.57 0-.285-.015-1.23-.015-2.235-3.015.555-3.795-.735-4.035-1.41-.135-.345-.72-1.41-1.23-1.695-.42-.225-1.02-.78-.015-.795.945-.015 1.62.87 1.845 1.23 1.08 1.815 2.805 1.305 3.495.99.105-.78.42-1.305.765-1.605-2.67-.3-5.46-1.335-5.46-5.925 0-1.305.465-2.385 1.23-3.225-.12-.3-.54-1.53.12-3.18 0 0 1.005-.315 3.3 1.23.96-.27 1.98-.405 3-.405s2.04.135 3 .405c2.295-1.56 3.3-1.23 3.3-1.23.66 1.65.24 2.88.12 3.18.765.84 1.23 1.905 1.23 3.225 0 4.605-2.805 5.625-5.475 5.925.435.375.81 1.095.81 2.22 0 1.605-.015 2.895-.015 3.3 0 .315.225.69.825.57A12.02 12.02 0 0024 12c0-6.63-5.37-12-12-12z"
+                />
+              </svg>
+              GitHub
+            </a>
+          </div>
           <a
-            href="https://github.com/Einere/tomato-mien"
-            class="inline-flex items-center gap-2 rounded-xl border border-gray-300 px-8 py-3 text-lg font-semibold transition hover:border-gray-400 hover:bg-gray-50 dark:border-gray-700 dark:hover:border-gray-600 dark:hover:bg-gray-900"
+            id="hero-other-platforms"
+            href="#installation"
+            class="hidden text-sm text-gray-500 underline underline-offset-2 transition hover:text-gray-700 dark:text-gray-400 dark:hover:text-gray-300"
           >
-            <svg class="h-5 w-5" fill="currentColor" viewBox="0 0 24 24">
-              <path
-                d="M12 0C5.37 0 0 5.37 0 12c0 5.31 3.435 9.795 8.205 11.385.6.105.825-.255.825-.57 0-.285-.015-1.23-.015-2.235-3.015.555-3.795-.735-4.035-1.41-.135-.345-.72-1.41-1.23-1.695-.42-.225-1.02-.78-.015-.795.945-.015 1.62.87 1.845 1.23 1.08 1.815 2.805 1.305 3.495.99.105-.78.42-1.305.765-1.605-2.67-.3-5.46-1.335-5.46-5.925 0-1.305.465-2.385 1.23-3.225-.12-.3-.54-1.53.12-3.18 0 0 1.005-.315 3.3 1.23.96-.27 1.98-.405 3-.405s2.04.135 3 .405c2.295-1.56 3.3-1.23 3.3-1.23.66 1.65.24 2.88.12 3.18.765.84 1.23 1.905 1.23 3.225 0 4.605-2.805 5.625-5.475 5.925.435.375.81 1.095.81 2.22 0 1.605-.015 2.895-.015 3.3 0 .315.225.69.825.57A12.02 12.02 0 0024 12c0-6.63-5.37-12-12-12z"
-              />
-            </svg>
-            GitHub
+            Other platforms
           </a>
         </div>
       </div>
@@ -129,8 +153,8 @@
             </div>
             <h3 class="mb-2 text-lg font-semibold">Audio & Visual Alerts</h3>
             <p class="text-gray-600 dark:text-gray-400">
-              Get notified with sound and visual alerts.
-              Visual alerts can be toggled on or off per rule.
+              Get notified with sound and visual alerts. Visual alerts can be
+              toggled on or off per rule.
             </p>
           </div>
           <!-- Feature 2: Simple Setup -->
@@ -181,10 +205,12 @@
                 />
               </svg>
             </div>
-            <h3 class="mb-2 text-lg font-semibold">Rule Management Dashboard</h3>
+            <h3 class="mb-2 text-lg font-semibold">
+              Rule Management Dashboard
+            </h3>
             <p class="text-gray-600 dark:text-gray-400">
-              A fast, intuitive dashboard to manage all your rules at a
-              glance. Search, sort, and toggle rules on or off instantly.
+              A fast, intuitive dashboard to manage all your rules at a glance.
+              Search, sort, and toggle rules on or off instantly.
             </p>
           </div>
           <!-- Feature 4: Background Notifications -->
@@ -210,8 +236,8 @@
             </div>
             <h3 class="mb-2 text-lg font-semibold">Runs in Background</h3>
             <p class="text-gray-600 dark:text-gray-400">
-              A fully offline app — no network required, ever. Your alarms
-              run reliably in the background and notify you right on time.
+              A fully offline app — no network required, ever. Your alarms run
+              reliably in the background and notify you right on time.
             </p>
           </div>
         </div>
@@ -335,8 +361,7 @@
             </div>
             <h3 class="mb-2 text-lg font-semibold">Set Filters (Optional)</h3>
             <p class="text-sm text-gray-600 dark:text-gray-400">
-              Restrict when alarms fire with time ranges (e.g. 9 AM - 5 PM
-              only)
+              Restrict when alarms fire with time ranges (e.g. 9 AM - 5 PM only)
             </p>
           </div>
           <!-- Step 4 -->
@@ -489,7 +514,7 @@
     </section>
 
     <!-- Installation -->
-    <section class="px-4 py-20 sm:py-28">
+    <section id="installation" class="px-4 py-20 sm:py-28">
       <div class="mx-auto max-w-5xl">
         <h2
           class="mb-4 text-center text-3xl font-bold tracking-tight sm:text-4xl"
@@ -507,8 +532,14 @@
             class="rounded-2xl border border-gray-200 bg-gray-50 p-6 text-center dark:border-gray-800 dark:bg-gray-900"
           >
             <div class="mb-4 flex justify-center">
-              <svg class="h-10 w-10 text-gray-700 dark:text-gray-300" viewBox="0 0 24 24" fill="currentColor">
-                <path d="M18.71 19.5c-.83 1.24-1.71 2.45-3.05 2.47-1.34.03-1.77-.79-3.29-.79-1.53 0-2 .77-3.27.82-1.31.05-2.3-1.32-3.14-2.53C4.25 17 2.94 12.45 4.7 9.39c.87-1.52 2.43-2.48 4.12-2.51 1.28-.02 2.5.87 3.29.87.78 0 2.26-1.07 3.8-.91.65.03 2.47.26 3.64 1.98-.09.06-2.17 1.28-2.15 3.81.03 3.02 2.65 4.03 2.68 4.04-.03.07-.42 1.44-1.38 2.83M13 3.5c.73-.83 1.94-1.46 2.94-1.5.13 1.17-.34 2.35-1.04 3.19-.69.85-1.83 1.51-2.95 1.42-.15-1.15.41-2.35 1.05-3.11z"/>
+              <svg
+                class="h-10 w-10 text-gray-700 dark:text-gray-300"
+                viewBox="0 0 24 24"
+                fill="currentColor"
+              >
+                <path
+                  d="M18.71 19.5c-.83 1.24-1.71 2.45-3.05 2.47-1.34.03-1.77-.79-3.29-.79-1.53 0-2 .77-3.27.82-1.31.05-2.3-1.32-3.14-2.53C4.25 17 2.94 12.45 4.7 9.39c.87-1.52 2.43-2.48 4.12-2.51 1.28-.02 2.5.87 3.29.87.78 0 2.26-1.07 3.8-.91.65.03 2.47.26 3.64 1.98-.09.06-2.17 1.28-2.15 3.81.03 3.02 2.65 4.03 2.68 4.04-.03.07-.42 1.44-1.38 2.83M13 3.5c.73-.83 1.94-1.46 2.94-1.5.13 1.17-.34 2.35-1.04 3.19-.69.85-1.83 1.51-2.95 1.42-.15-1.15.41-2.35 1.05-3.11z"
+                />
               </svg>
             </div>
             <h3 class="mb-2 text-lg font-semibold">macOS</h3>
@@ -516,6 +547,7 @@
               Download and install the .dmg file
             </p>
             <a
+              id="download-macos"
               href="https://github.com/Einere/tomato-mien/releases/latest"
               class="bg-tomato-600 hover:bg-tomato-700 inline-block rounded-lg px-6 py-2 text-sm font-semibold text-white transition"
             >
@@ -527,8 +559,14 @@
             class="rounded-2xl border border-gray-200 bg-gray-50 p-6 text-center dark:border-gray-800 dark:bg-gray-900"
           >
             <div class="mb-4 flex justify-center">
-              <svg class="h-10 w-10 text-gray-700 dark:text-gray-300" viewBox="0 0 24 24" fill="currentColor">
-                <path d="M3 12V6.75l8-1.25V12H3zm0 .5h8v6.5l-8-1.25V12.5zM11.5 5.35l9.5-1.6V12h-9.5V5.35zM11.5 12.5H21v7.75l-9.5-1.6V12.5z"/>
+              <svg
+                class="h-10 w-10 text-gray-700 dark:text-gray-300"
+                viewBox="0 0 24 24"
+                fill="currentColor"
+              >
+                <path
+                  d="M3 12V6.75l8-1.25V12H3zm0 .5h8v6.5l-8-1.25V12.5zM11.5 5.35l9.5-1.6V12h-9.5V5.35zM11.5 12.5H21v7.75l-9.5-1.6V12.5z"
+                />
               </svg>
             </div>
             <h3 class="mb-2 text-lg font-semibold">Windows</h3>
@@ -536,6 +574,7 @@
               Download and run the .exe installer
             </p>
             <a
+              id="download-windows"
               href="https://github.com/Einere/tomato-mien/releases/latest"
               class="bg-tomato-600 hover:bg-tomato-700 inline-block rounded-lg px-6 py-2 text-sm font-semibold text-white transition"
             >
@@ -548,7 +587,10 @@
                 SmartScreen Warning
               </summary>
               <div class="mt-2 text-xs text-gray-500 dark:text-gray-500">
-                <p>The installer is not code-signed yet, so Windows SmartScreen may block it.</p>
+                <p>
+                  The installer is not code-signed yet, so Windows SmartScreen
+                  may block it.
+                </p>
                 <ol class="mt-1 list-inside list-decimal">
                   <li>Click "More info" on the SmartScreen popup</li>
                   <li>Click "Run anyway" to proceed with the installation</li>
@@ -561,8 +603,14 @@
             class="rounded-2xl border border-gray-200 bg-gray-50 p-6 text-center dark:border-gray-800 dark:bg-gray-900"
           >
             <div class="mb-4 flex justify-center">
-              <svg class="h-10 w-10 text-gray-700 dark:text-gray-300" viewBox="0 0 256 256" fill="currentColor">
-                <path d="M161.22 209.74a4 4 0 0 1-3.31 6.26H98.1a4 4 0 0 1-3.31-6.26a40 40 0 0 1 66.43 0m68.93 3.37a8.29 8.29 0 0 1-6.43 2.89h-39.16a4 4 0 0 1-3.76-2.65a56 56 0 0 0-105.59 0a4 4 0 0 1-3.76 2.65H32.23a8.2 8.2 0 0 1-6.42-2.93a8 8 0 0 1-.06-10.07c.06-.07 7.64-9.78 15.12-28.72C47.77 156.8 56 127.64 56 88a72 72 0 0 1 144 0c0 39.64 8.23 68.8 15.13 86.28c7.48 18.94 15.06 28.65 15.13 28.74a8 8 0 0 1-.11 10.09M88 100a12 12 0 1 0 12-12a12 12 0 0 0-12 12m79.16 32.42a8 8 0 0 0-10.73-3.58L128 143.06l-28.42-14.22a8 8 0 0 0-7.15 14.32l32 16a8 8 0 0 0 7.15 0l32-16a8 8 0 0 0 3.58-10.74M168 100a12 12 0 1 0-12 12a12 12 0 0 0 12-12"/>
+              <svg
+                class="h-10 w-10 text-gray-700 dark:text-gray-300"
+                viewBox="0 0 256 256"
+                fill="currentColor"
+              >
+                <path
+                  d="M161.22 209.74a4 4 0 0 1-3.31 6.26H98.1a4 4 0 0 1-3.31-6.26a40 40 0 0 1 66.43 0m68.93 3.37a8.29 8.29 0 0 1-6.43 2.89h-39.16a4 4 0 0 1-3.76-2.65a56 56 0 0 0-105.59 0a4 4 0 0 1-3.76 2.65H32.23a8.2 8.2 0 0 1-6.42-2.93a8 8 0 0 1-.06-10.07c.06-.07 7.64-9.78 15.12-28.72C47.77 156.8 56 127.64 56 88a72 72 0 0 1 144 0c0 39.64 8.23 68.8 15.13 86.28c7.48 18.94 15.06 28.65 15.13 28.74a8 8 0 0 1-.11 10.09M88 100a12 12 0 1 0 12-12a12 12 0 0 0-12 12m79.16 32.42a8 8 0 0 0-10.73-3.58L128 143.06l-28.42-14.22a8 8 0 0 0-7.15 14.32l32 16a8 8 0 0 0 7.15 0l32-16a8 8 0 0 0 3.58-10.74M168 100a12 12 0 1 0-12 12a12 12 0 0 0 12-12"
+                />
               </svg>
             </div>
             <h3 class="mb-2 text-lg font-semibold">Linux</h3>
@@ -570,6 +618,7 @@
               Download and run the AppImage
             </p>
             <a
+              id="download-linux"
               href="https://github.com/Einere/tomato-mien/releases/latest"
               class="bg-tomato-600 hover:bg-tomato-700 inline-block rounded-lg px-6 py-2 text-sm font-semibold text-white transition"
             >
@@ -606,14 +655,12 @@ npm run electron</code></pre>
       <div class="mx-auto max-w-5xl">
         <div class="mb-12 text-center">
           <div class="mb-4 text-5xl">&#9749;</div>
-          <h2
-            class="mb-3 text-3xl font-bold tracking-tight sm:text-4xl"
-          >
+          <h2 class="mb-3 text-3xl font-bold tracking-tight sm:text-4xl">
             Support This Project
           </h2>
           <p class="mx-auto max-w-md text-gray-600 dark:text-gray-400">
-            If you find Tomato Mien useful, consider buying me a coffee.
-            Your support helps keep this project alive!
+            If you find Tomato Mien useful, consider buying me a coffee. Your
+            support helps keep this project alive!
           </p>
         </div>
         <div class="mx-auto grid max-w-2xl gap-6 sm:grid-cols-2">
@@ -691,6 +738,7 @@ npm run electron</code></pre>
     </section>
 
     <script>
+      // Toss QR toggle
       const toggle = document.getElementById("toss-toggle");
       const qr = document.getElementById("toss-qr");
       const chevron = document.getElementById("toss-chevron");
@@ -702,10 +750,144 @@ npm run electron</code></pre>
           ? "Show QR Code"
           : "Hide QR Code";
       });
+
+      // OS detection & auto-download
+      (function () {
+        const API_URL =
+          "https://api.github.com/repos/Einere/tomato-mien/releases/latest";
+        const CACHE_KEY = "tm_release_cache";
+        const CACHE_TTL = 30 * 60 * 1000; // 30 minutes
+
+        const OS_LABELS = {
+          macos: "Download for macOS",
+          windows: "Download for Windows",
+          linux: "Download for Linux",
+        };
+
+        function detectOS() {
+          const ua = navigator.userAgent;
+          if (/Macintosh|Mac OS X/.test(ua)) return "macos";
+          if (/Windows/.test(ua)) return "windows";
+          if (/Linux/.test(ua) && !/Android/.test(ua)) return "linux";
+          return "unknown";
+        }
+
+        function updateHeroLabel(os) {
+          const label = OS_LABELS[os];
+          if (!label) return;
+          document.getElementById("hero-download-label").textContent = label;
+          document
+            .getElementById("hero-other-platforms")
+            .classList.remove("hidden");
+        }
+
+        function safeUrl(url) {
+          return url && url.startsWith("https://github.com/") ? url : null;
+        }
+
+        function findAsset(assets, extension, archSuffix) {
+          for (let i = 0; i < assets.length; i++) {
+            const name = assets[i].name;
+            if (!name.endsWith(extension)) continue;
+            if (archSuffix && name.includes(archSuffix))
+              return safeUrl(assets[i].browser_download_url);
+            if (!archSuffix && !name.includes("arm64"))
+              return safeUrl(assets[i].browser_download_url);
+          }
+          return null;
+        }
+
+        function updateButtons(assets) {
+          const macArm = findAsset(assets, ".dmg", "arm64");
+          const macIntel = findAsset(assets, ".dmg", null);
+          const win = findAsset(assets, ".exe", null);
+          const linuxX64 = findAsset(assets, ".AppImage", null);
+
+          // Installation section buttons — prefer arm64 for macOS, fallback to Intel
+          const macUrl = macArm || macIntel;
+          if (macUrl) document.getElementById("download-macos").href = macUrl;
+          if (win) document.getElementById("download-windows").href = win;
+          if (linuxX64)
+            document.getElementById("download-linux").href = linuxX64;
+
+          // Hero button
+          const os = detectOS();
+          const heroBtn = document.getElementById("hero-download-btn");
+          updateHeroLabel(os);
+
+          if (os === "macos" && macUrl) heroBtn.href = macUrl;
+          else if (os === "windows" && win) heroBtn.href = win;
+          else if (os === "linux" && linuxX64) heroBtn.href = linuxX64;
+        }
+
+        // Update hero label immediately (before API call)
+        updateHeroLabel(detectOS());
+
+        // Try sessionStorage cache first
+        function getCachedAssets() {
+          try {
+            const raw = sessionStorage.getItem(CACHE_KEY);
+            if (!raw) return null;
+            const cached = JSON.parse(raw);
+            if (Date.now() - cached.ts < CACHE_TTL) return cached.assets;
+            sessionStorage.removeItem(CACHE_KEY);
+          } catch (e) {
+            // Ignore storage errors
+          }
+          return null;
+        }
+
+        function cacheAssets(assets) {
+          try {
+            sessionStorage.setItem(
+              CACHE_KEY,
+              JSON.stringify({ ts: Date.now(), assets }),
+            );
+          } catch (e) {
+            // Ignore storage errors
+          }
+        }
+
+        const cached = getCachedAssets();
+        if (cached) {
+          updateButtons(cached);
+          return;
+        }
+
+        // Fetch latest release assets
+        const controller =
+          typeof AbortController !== "undefined" ? new AbortController() : null;
+        const fetchOptions = {
+          headers: { Accept: "application/vnd.github.v3+json" },
+        };
+        if (controller) {
+          fetchOptions.signal = controller.signal;
+          setTimeout(function () {
+            controller.abort();
+          }, 10000);
+        }
+
+        fetch(API_URL, fetchOptions)
+          .then(function (res) {
+            if (!res.ok) throw new Error("GitHub API " + res.status);
+            return res.json();
+          })
+          .then(function (data) {
+            if (data.assets && data.assets.length > 0) {
+              cacheAssets(data.assets);
+              updateButtons(data.assets);
+            }
+          })
+          .catch(function () {
+            // Silently fall back to releases page links
+          });
+      })();
     </script>
 
     <!-- Footer -->
-    <footer class="border-t border-gray-200 px-4 py-12 dark:border-gray-800 bg-gray-50">
+    <footer
+      class="border-t border-gray-200 bg-gray-50 px-4 py-12 dark:border-gray-800"
+    >
       <div
         class="mx-auto flex max-w-5xl flex-col items-center gap-4 text-center text-sm text-gray-500 dark:text-gray-500"
       >


### PR DESCRIPTION
## 개요

- 랜딩 페이지 Download 버튼에 OS 자동 감지 기능 추가
- GitHub API로 최신 릴리스 에셋을 가져와 직접 다운로드 링크로 연결
- 감지 실패/API 오류 시 기존 releases 페이지로 graceful fallback

## 변경 내용

- **Hero 섹션**: `navigator.userAgent` 기반으로 "Download for macOS/Windows/Linux" 라벨 동적 표시 + "Other platforms" 링크(Installation 섹션으로 스크롤)
- **Installation 섹션**: 각 OS 버튼에 `id` 부여(`download-macos`, `download-windows`, `download-linux`), `id="installation"` 앵커 추가
- **JS 로직**: `detectOS()`, `findAsset()`, `updateButtons()` 등 클라이언트 JS로 구현
  - `sessionStorage` 캐싱 (30분 TTL)으로 GitHub API rate limit (60회/시간) 완화
  - `safeUrl()`로 `https://github.com/` 출처만 허용
  - macOS: arm64 우선, Intel fallback 지원
  - `AbortController` 10초 timeout + 호환성 체크

## 테스트 계획

- [x] `npm run docs:dev`로 개발 서버 실행 후 Hero Download 버튼 라벨이 현재 OS로 표시되는지 확인
- [x] 버튼 클릭 시 직접 다운로드가 시작되는지 확인
- [x] DevTools에서 User-Agent를 다른 OS로 변경하여 각 OS별 동작 확인
- [x] Network 탭에서 API 요청 차단 시 releases 페이지로 fallback되는지 확인
- [x] "Other platforms" 클릭 시 Installation 섹션으로 스크롤되는지 확인
- [x] 페이지 새로고침 시 sessionStorage 캐시로 API 재호출 없이 동작하는지 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)