### PR TITLE
chore: split MAS provisioning profiles

### DIFF
--- a/.github/workflows/build-and-release.yml
+++ b/.github/workflows/build-and-release.yml
@@ -157,8 +157,8 @@ jobs:
           APPLE_PROVISIONING_PROFILE: ${{ secrets.APPLE_PROVISIONING_PROFILE }}
         run: |
           mkdir -p ~/Library/MobileDevice/Provisioning\ Profiles
-          echo -n "$APPLE_PROVISIONING_PROFILE" | base64 --decode -o electron/entitlements/embedded.provisionprofile
-          cp electron/entitlements/embedded.provisionprofile ~/Library/MobileDevice/Provisioning\ Profiles/
+          echo -n "$APPLE_PROVISIONING_PROFILE" | base64 --decode -o electron/entitlements/embedded.mas.provisionprofile
+          cp electron/entitlements/embedded.mas.provisionprofile ~/Library/MobileDevice/Provisioning\ Profiles/
 
       - name: Build MAS app
         run: npm run electron:mas:dist

--- a/.gitignore
+++ b/.gitignore
@@ -34,8 +34,8 @@ coverage/
 .cache
 .parcel-cache
 
-# Provisioning profile (binary, per-machine)
-electron/entitlements/embedded.provisionprofile
+# Provisioning profiles (binary, per-machine)
+electron/entitlements/embedded*.provisionprofile
 
 # Screenshots (local store submission assets)
 screenshots/

--- a/README.md
+++ b/README.md
@@ -34,6 +34,12 @@ npm run build
 npm run electron:release
 ```
 
+### macOS 빌드 프로필
+
+- `npm run electron:mas:dev`: 로컬 Mac App Store Sandbox 테스트용 (`electron/entitlements/embedded.dev.provisionprofile`)
+- `npm run electron:mas:dist`: Mac App Store 제출용 (`electron/entitlements/embedded.mas.provisionprofile`)
+- `npm run electron:dist`: Mac App Store 외부 배포용 (`Developer ID Application` 서명 + 공증)
+
 ## 프로젝트 구조
 
 npm workspaces 기반 모노레포:

--- a/electron/entitlements/entitlements.mas.plist
+++ b/electron/entitlements/entitlements.mas.plist
@@ -9,13 +9,5 @@
     <!-- 네트워크 클라이언트 (외부 링크 열기 등) -->
     <key>com.apple.security.network.client</key>
     <true/>
-
-    <!-- Electron/Chromium 요구사항 -->
-    <key>com.apple.security.cs.allow-jit</key>
-    <true/>
-    <key>com.apple.security.cs.allow-unsigned-executable-memory</key>
-    <true/>
-    <key>com.apple.security.cs.allow-dyld-environment-variables</key>
-    <true/>
 </dict>
 </plist>

--- a/package.json
+++ b/package.json
@@ -45,9 +45,9 @@
     "electron:dev": "concurrently \"npm run dev\" \"wait-on http://localhost:5173 && NODE_ENV=development electron .\"",
     "electron:dist": "npm run build && electron-builder --publish=never",
     "electron:release": "npm run build && electron-builder",
-    "electron:mas:dev": "npm run build && MAS_BUILD=true electron-builder --mac mas-dev --publish=never",
-    "electron:mas:dist": "npm run build && MAS_BUILD=true electron-builder --mac mas --publish=never",
-    "electron:mas:release": "npm run build && MAS_BUILD=true electron-builder --mac mas",
+    "electron:mas:dev": "npm run build && MAS_BUILD=true electron-builder --mac mas-dev --publish=never -c.mas.type=development -c.mas.provisioningProfile=electron/entitlements/embedded.dev.provisionprofile",
+    "electron:mas:dist": "npm run build && MAS_BUILD=true electron-builder --mac mas --publish=never -c.mas.provisioningProfile=electron/entitlements/embedded.mas.provisionprofile",
+    "electron:mas:release": "npm run build && MAS_BUILD=true electron-builder --mac mas -c.mas.provisioningProfile=electron/entitlements/embedded.mas.provisionprofile",
     "docs:dev": "npm run dev -w @tomato-mien/docs",
     "docs:build": "npm run build -w @tomato-mien/docs",
     "release": "npm version $npm_config_tag --no-git-tag-version && git add package.json package-lock.json && git commit -m \"chore: bump version to $npm_config_tag\" && git tag v$npm_config_tag && git push && git push origin v$npm_config_tag"
@@ -173,8 +173,8 @@
       "hardenedRuntime": false,
       "entitlements": "electron/entitlements/entitlements.mas.plist",
       "entitlementsInherit": "electron/entitlements/entitlements.mas.inherit.plist",
-      "entitlementsLoginHelper": "electron/entitlements/entitlements.mas.inherit.plist",
-      "provisioningProfile": "electron/entitlements/embedded.provisionprofile",
+      "entitlementsLoginHelper": "electron/entitlements/entitlements.mas.plist",
+      "provisioningProfile": "electron/entitlements/embedded.mas.provisionprofile",
       "category": "public.app-category.productivity",
       "target": [
         {


### PR DESCRIPTION
## Summary
- split MAS development and distribution provisioning profiles in build scripts
- point CI MAS builds at the distribution provisioning profile path
- document macOS build profile usage in the README

## Testing
- not run (configuration-only changes)